### PR TITLE
Add SystemControl blanket trait and update I2C HAL   integration

### DIFF
--- a/hal/blocking/src/lib.rs
+++ b/hal/blocking/src/lib.rs
@@ -34,3 +34,6 @@ pub use embedded_hal::delay::DelayNs;
 pub use embedded_hal::digital::{InputPin, OutputPin, StatefulOutputPin};
 pub use embedded_hal::i2c::{I2c, SevenBitAddress, TenBitAddress};
 pub use embedded_hal::spi::{SpiBus, SpiDevice};
+
+// Re-export system control traits
+pub use system_control::{ClockControl, ResetControl, SystemControl};

--- a/hal/blocking/src/system_control.rs
+++ b/hal/blocking/src/system_control.rs
@@ -260,3 +260,40 @@ pub trait ResetControl: ErrorType {
     /// * `Result<bool, Self::Error>` - Ok with a boolean indicating if the reset is asserted, or an error of type `Self::Error`.
     fn reset_is_asserted(&self, reset_id: &Self::ResetId) -> Result<bool, Self::Error>;
 }
+
+/// Blanket trait that combines clock and reset control functionality.
+///
+/// This trait provides a unified interface for system control operations,
+/// combining both clock management and reset control capabilities. It is
+/// automatically implemented for any type that implements both `ClockControl`
+/// and `ResetControl` with the same error type.
+///
+/// # Design
+///
+/// The blanket implementation pattern allows consumers to use a single trait
+/// bound for system control operations while maintaining the flexibility of
+/// separate, composable traits for clock and reset functionality.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// fn configure_system<T: SystemControl>(controller: &mut T)
+/// where
+///     T::ClockId: From<u32>,
+///     T::ResetId: From<u32>,
+///     T::ClockConfig: Default,
+/// {
+///     // Enable peripheral clock
+///     controller.enable(&T::ClockId::from(42)).unwrap();
+///
+///     // Release from reset
+///     controller.reset_deassert(&T::ResetId::from(42)).unwrap();
+/// }
+/// ```
+pub trait SystemControl: ClockControl + ResetControl {}
+
+/// Blanket implementation of SystemControl for types implementing both traits.
+///
+/// This implementation is automatically provided for any type that implements
+/// both `ClockControl` and `ResetControl` with compatible error types.
+impl<T> SystemControl for T where T: ClockControl + ResetControl {}

--- a/platform/impls/baremetal/mock/src/i2c_hardware.rs
+++ b/platform/impls/baremetal/mock/src/i2c_hardware.rs
@@ -598,15 +598,15 @@ impl I2cHardwareCore for MockI2cHardware {
     /// The closure is called with a mutable reference to the provided clock controller,
     /// enabling validation of clock configuration calls and simulation of various
     /// clock-related scenarios.
-    fn init_with_clock_control<F, C>(
+    fn init_with_system_control<F, S>(
         &mut self,
         config: &mut Self::Config,
-        _clock_setup: F,
+        _system_setup: F,
     ) -> Result<(), Self::Error>
     where
-        F: FnOnce(&mut C) -> Result<(), <C as system_control::ErrorType>::Error>,
-        C: system_control::ClockControl,
-        Self::Error: From<<C as system_control::ErrorType>::Error>,
+        F: FnOnce(&mut S) -> Result<(), <S as system_control::ErrorType>::Error>,
+        S: system_control::SystemControl,
+        Self::Error: From<<S as system_control::ErrorType>::Error>,
     {
         // First check if the mock is configured to succeed
         self.check_success()?;
@@ -615,9 +615,9 @@ impl I2cHardwareCore for MockI2cHardware {
         self.config = *config;
         self.initialized = true;
 
-        // The mock doesn't actually call the closure since we don't have a real clock controller
-        // In a real test, you would provide a mock clock controller and call:
-        // clock_setup(&mut mock_clock_controller)?;
+        // The mock doesn't actually call the closure since we don't have a real system controller
+        // In a real test, you would provide a mock system controller and call:
+        // system_setup(&mut mock_system_controller)?;
 
         Ok(())
     }
@@ -660,16 +660,16 @@ impl I2cHardwareCore for MockI2cHardware {
     ///
     /// assert!(result.is_ok());
     /// ```
-    fn configure_timing_with_clock_control<F, C>(
+    fn configure_timing_with_system_control<F, S>(
         &mut self,
         speed: Self::I2cSpeed,
         _timing: &Self::TimingConfig,
-        _clock_config: F,
+        _system_config: F,
     ) -> Result<u32, Self::Error>
     where
-        F: FnOnce(&mut C) -> Result<u64, <C as system_control::ErrorType>::Error>,
-        C: system_control::ClockControl,
-        Self::Error: From<<C as system_control::ErrorType>::Error>,
+        F: FnOnce(&mut S) -> Result<u64, <S as system_control::ErrorType>::Error>,
+        S: system_control::SystemControl,
+        Self::Error: From<<S as system_control::ErrorType>::Error>,
     {
         // Check if the mock is configured to succeed
         self.check_success()?;
@@ -677,9 +677,9 @@ impl I2cHardwareCore for MockI2cHardware {
         // Update the mock's frequency setting
         self.config.frequency = speed;
 
-        // The mock doesn't actually call the closure since we don't have a real clock controller
-        // In a real test, you would provide a mock clock controller and call:
-        // let _clock_freq = clock_config(&mut mock_clock_controller)?;
+        // The mock doesn't actually call the closure since we don't have a real system controller
+        // In a real test, you would provide a mock system controller and call:
+        // let _system_freq = system_config(&mut mock_system_controller)?;
 
         // Return the requested speed as the "actual" frequency for the mock
         Ok(speed)


### PR DESCRIPTION

  - Add SystemControl trait combining ClockControl + ResetControl
  - Update I2C hardware traits to use SystemControl instead of ClockControl
  - Rename init_with_clock_control to init_with_system_control
  - Rename configure_timing_with_clock_control to configure_timing_with_system_control
  - Update mock implementation to match new trait signatures
  - Improve documentation with reset management examples