### PR TITLE
target/ast10x0/peripherals/sgpiom: add interrupts and harden validation

### DIFF
--- a/target/ast10x0/peripherals/scu/pinctrl.rs
+++ b/target/ast10x0/peripherals/scu/pinctrl.rs
@@ -555,6 +555,19 @@ pub const PINCTRL_FMC_QUAD: &[PinctrlPin] = &[PIN_SCU430_10, PIN_SCU430_11];
 /// I2C communication between the two AST1060 daughter cards.
 pub const PINCTRL_I2C2: &[PinctrlPin] = &[PIN_SCU418_0, PIN_SCU418_1];
 
+/// SGPIOM (Serial GPIO Master) pin group: mux selection on SCU41C[8:11].
+///
+/// Enables the four SGPIOM serial pins:
+///   - bit 8  `sgpmclk` — serial clock out
+///   - bit 9  `sgpmld`  — load/latch out
+///   - bit 10 `sgpmo`   — serial data out
+///   - bit 11 `sgpmi`   — serial data in
+///
+/// Mux bits derived from the AST10x0 datasheet / Zephyr `ast10x0-pinctrl.dtsi`
+/// (`pin_sgpmclk/ld/o/i` = `SIG_DESC_SET(0x41C, 8..11)`).
+pub const PINCTRL_SGPIOM: &[PinctrlPin] =
+    &[PIN_SCU41C_8, PIN_SCU41C_9, PIN_SCU41C_10, PIN_SCU41C_11];
+
 /// Macro to safely modify a register bit (set or clear).
 macro_rules! modify_reg {
     ($reg:expr, $bit:expr, $clear:expr) => {{

--- a/target/ast10x0/peripherals/sgpiom/hal_impl.rs
+++ b/target/ast10x0/peripherals/sgpiom/hal_impl.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use openprot_hal_blocking::gpio_port::{
-    ActivePolarity, GpioBankPassthrough, GpioError, GpioErrorKind, GpioErrorType, GpioPort,
-    PinConfig, PinDirection, PinMask,
+    ActivePolarity, EdgeSensitivity, GpioBankPassthrough, GpioError, GpioErrorKind, GpioErrorType,
+    GpioInterrupt, GpioPort, InterruptOperation, PinConfig, PinDirection, PinMask,
 };
 
 use super::register_block::Sgpiom;
-use super::types::{BankDevice, Error};
+use super::types::{BankDevice, Error, InterruptMode, InterruptTrigger};
 
 /// 32-bit pin mask for a single SGPIOM bank.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -85,14 +85,7 @@ impl GpioPort for SgpiomBankPort {
 
     fn configure(&mut self, pins: Self::Mask, config: Self::Config) -> Result<(), Self::Error> {
         // Reject pins outside this bank's ngpios window.
-        let valid_mask: u32 = if self.dev.ngpios >= 32 {
-            u32::MAX
-        } else {
-            (1u32 << self.dev.ngpios) - 1
-        };
-        if (pins.0 & !valid_mask) != 0 {
-            return Err(Error::InvalidPin);
-        }
+        self.dev.validate_mask(pins.0)?;
 
         if config.direction == PinDirection::Output {
             if let Some(logical_high) = config.initial_output {
@@ -118,6 +111,7 @@ impl GpioPort for SgpiomBankPort {
         set_mask: Self::Mask,
         reset_mask: Self::Mask,
     ) -> Result<(), Self::Error> {
+        self.dev.validate_mask(set_mask.0 | reset_mask.0)?;
         // Atomically apply both masks: set wins over reset for overlapping bits.
         self.sgpiom
             .port_set_masked_raw(self.dev.bank, set_mask.0 | reset_mask.0, set_mask.0);
@@ -129,14 +123,94 @@ impl GpioPort for SgpiomBankPort {
     }
 
     fn toggle(&mut self, pins: Self::Mask) -> Result<(), Self::Error> {
+        self.dev.validate_mask(pins.0)?;
         self.sgpiom.port_toggle_bits(self.dev.bank, pins.0);
         Ok(())
+    }
+}
+
+impl GpioInterrupt for SgpiomBankPort {
+    type Mask = SgpiomMask;
+
+    /// Program interrupt sensitivity for the masked pins.
+    ///
+    /// Only sensitivity is written here; enabling/disabling is done via
+    /// [`GpioInterrupt::irq_control`] — matching the EarlGrey driver split.
+    fn irq_configure(
+        &mut self,
+        mask: Self::Mask,
+        sensitivity: EdgeSensitivity,
+    ) -> Result<(), Self::Error> {
+        // Validate up front so a mixed valid/invalid mask cannot partially
+        // program some pins before erroring.
+        self.dev.validate_mask(mask.0)?;
+
+        let (mode, trig) = match sensitivity {
+            EdgeSensitivity::RisingEdge => (InterruptMode::Edge, InterruptTrigger::High),
+            EdgeSensitivity::FallingEdge => (InterruptMode::Edge, InterruptTrigger::Low),
+            EdgeSensitivity::BothEdges => (InterruptMode::Edge, InterruptTrigger::Both),
+            EdgeSensitivity::HighLevel => (InterruptMode::Level, InterruptTrigger::High),
+            EdgeSensitivity::LowLevel => (InterruptMode::Level, InterruptTrigger::Low),
+        };
+
+        let mut pins = mask.0;
+        while pins != 0 {
+            let pin = pins.trailing_zeros() as u8;
+            self.sgpiom
+                .configure_interrupt_sensitivity(&self.dev, pin, mode, trig)?;
+            pins &= pins - 1;
+        }
+        Ok(())
+    }
+
+    /// Enable/disable/clear/query interrupts for the masked pins.
+    fn irq_control(
+        &mut self,
+        mask: Self::Mask,
+        operation: InterruptOperation,
+    ) -> Result<bool, Self::Error> {
+        self.dev.validate_mask(mask.0)?;
+        match operation {
+            InterruptOperation::Enable => {
+                // Clear stale status first to avoid a spurious immediate fire.
+                self.sgpiom.clear_interrupt_status(self.dev.bank, mask.0);
+                self.sgpiom.set_interrupt_enable(self.dev.bank, mask.0);
+                Ok(true)
+            }
+            InterruptOperation::Disable => {
+                self.sgpiom.clear_interrupt_enable(self.dev.bank, mask.0);
+                Ok(true)
+            }
+            InterruptOperation::Clear => {
+                self.sgpiom.clear_interrupt_status(self.dev.bank, mask.0);
+                Ok(true)
+            }
+            InterruptOperation::IsPending => {
+                let status = self.sgpiom.interrupt_status(self.dev.bank);
+                Ok((status & mask.0) != 0)
+            }
+        }
+    }
+
+    /// Callback registration is unsupported: in the OpenPRoT microkernel
+    /// architecture interrupts are delivered to userspace via wait-on-object
+    /// syscalls rather than in-driver callbacks (same as the EarlGrey driver).
+    fn register_interrupt_handler<F>(
+        &mut self,
+        _mask: Self::Mask,
+        _handler: F,
+    ) -> Result<(), Self::Error>
+    where
+        F: FnMut(Self::Mask) + Send + 'static,
+    {
+        Err(Error::UnsupportedFlags)
     }
 }
 
 impl GpioBankPassthrough for SgpiomBankPort {
     /// Sample current inputs for `mask` pins and write them to the output latch (one-shot).
     fn set_passthrough_mask(&mut self, mask: Self::Mask) -> Result<(), Self::Error> {
+        self.dev.validate_mask(mask.0)?;
         self.sgpiom.passthrough_masked(self.dev.bank, mask.0);
         Ok(())
     }

--- a/target/ast10x0/peripherals/sgpiom/hal_impl.rs
+++ b/target/ast10x0/peripherals/sgpiom/hal_impl.rs
@@ -141,10 +141,6 @@ impl GpioInterrupt for SgpiomBankPort {
         mask: Self::Mask,
         sensitivity: EdgeSensitivity,
     ) -> Result<(), Self::Error> {
-        // Validate up front so a mixed valid/invalid mask cannot partially
-        // program some pins before erroring.
-        self.dev.validate_mask(mask.0)?;
-
         let (mode, trig) = match sensitivity {
             EdgeSensitivity::RisingEdge => (InterruptMode::Edge, InterruptTrigger::High),
             EdgeSensitivity::FallingEdge => (InterruptMode::Edge, InterruptTrigger::Low),
@@ -153,14 +149,8 @@ impl GpioInterrupt for SgpiomBankPort {
             EdgeSensitivity::LowLevel => (InterruptMode::Level, InterruptTrigger::Low),
         };
 
-        let mut pins = mask.0;
-        while pins != 0 {
-            let pin = pins.trailing_zeros() as u8;
-            self.sgpiom
-                .configure_interrupt_sensitivity(&self.dev, pin, mode, trig)?;
-            pins &= pins - 1;
-        }
-        Ok(())
+        self.sgpiom
+            .configure_interrupt_sensitivity_masked(&self.dev, mask.0, mode, trig)
     }
 
     /// Enable/disable/clear/query interrupts for the masked pins.

--- a/target/ast10x0/peripherals/sgpiom/register_block.rs
+++ b/target/ast10x0/peripherals/sgpiom/register_block.rs
@@ -212,26 +212,46 @@ impl Sgpiom {
         Ok(Some(int_type))
     }
 
-    /// Write the 3-bit sensitivity code for a single `bit` into the bank's
-    /// `int_sens_type[0..2]` registers, leaving other pins untouched.
-    fn write_sens_bits(&self, bank: Bank, bit: u32, int_type: u8) {
-        let mut s0 = self.int_sens_read(bank, 0) & !bit;
-        let mut s1 = self.int_sens_read(bank, 1) & !bit;
-        let mut s2 = self.int_sens_read(bank, 2) & !bit;
+    /// Write the 3-bit sensitivity code for every set bit in `mask` into the
+    /// bank's `int_sens_type[0..2]` registers, leaving other pins untouched.
+    ///
+    /// The three sensitivity registers can only be rewritten one at a time, so
+    /// a pin whose interrupt is enabled would pass through transient codes
+    /// while they are updated (e.g. level-high `011` -> falling-edge `000`
+    /// passes through level-low `010` after the first write) and could latch a
+    /// spurious interrupt. To prevent that, any currently enabled pins in
+    /// `mask` are disabled for the duration of the update; status latched
+    /// under the old or transient sensitivity is cleared before their enable
+    /// bits are restored.
+    fn write_sens_bits(&self, bank: Bank, mask: u32, int_type: u8) {
+        let en = self.int_en_read(bank);
+        let enabled = en & mask;
+        if enabled != 0 {
+            self.int_en_write(bank, en & !mask);
+        }
+
+        let mut s0 = self.int_sens_read(bank, 0) & !mask;
+        let mut s1 = self.int_sens_read(bank, 1) & !mask;
+        let mut s2 = self.int_sens_read(bank, 2) & !mask;
 
         if (int_type & 0x1) != 0 {
-            s0 |= bit;
+            s0 |= mask;
         }
         if (int_type & 0x2) != 0 {
-            s1 |= bit;
+            s1 |= mask;
         }
         if (int_type & 0x4) != 0 {
-            s2 |= bit;
+            s2 |= mask;
         }
 
         self.int_sens_write(bank, 0, s0);
         self.int_sens_write(bank, 1, s1);
         self.int_sens_write(bank, 2, s2);
+
+        if enabled != 0 {
+            self.clear_interrupt_status(bank, enabled);
+            self.int_en_write(bank, self.int_en_read(bank) | enabled);
+        }
     }
 
     /// Configure a pin's interrupt sensitivity *and* enable/disable bit.
@@ -255,9 +275,13 @@ impl Sgpiom {
                 self.int_en_write(dev.bank, en);
             }
             Some(int_type) => {
+                // Program sensitivity while the pin is (still) disabled, then
+                // clear any status latched under the previous sensitivity so a
+                // stale event cannot fire the moment the enable bit is set.
+                self.write_sens_bits(dev.bank, bit, int_type);
+                self.clear_interrupt_status(dev.bank, bit);
                 let en = self.int_en_read(dev.bank) | bit;
                 self.int_en_write(dev.bank, en);
-                self.write_sens_bits(dev.bank, bit, int_type);
             }
         }
 
@@ -275,11 +299,29 @@ impl Sgpiom {
         trig: InterruptTrigger,
     ) -> Result<(), Error> {
         dev.validate_pin(pin)?;
-        let bit = 1u32 << pin;
         // Disabled has no sensitivity to program; treat as code 0 (falling edge)
         // which is inert while the enable bit stays clear.
         let int_type = Self::interrupt_sens_type(mode, trig)?.unwrap_or(0);
-        self.write_sens_bits(dev.bank, bit, int_type);
+        self.write_sens_bits(dev.bank, 1u32 << pin, int_type);
+        Ok(())
+    }
+
+    /// Program interrupt sensitivity for every pin in `mask` in one pass
+    /// (three register read-modify-writes total, instead of three per pin).
+    /// Like [`Self::configure_interrupt_sensitivity`], the enable bits are not
+    /// changed.
+    pub fn configure_interrupt_sensitivity_masked(
+        &self,
+        dev: &BankDevice,
+        mask: u32,
+        mode: InterruptMode,
+        trig: InterruptTrigger,
+    ) -> Result<(), Error> {
+        dev.validate_mask(mask)?;
+        let int_type = Self::interrupt_sens_type(mode, trig)?.unwrap_or(0);
+        if mask != 0 {
+            self.write_sens_bits(dev.bank, mask, int_type);
+        }
         Ok(())
     }
 

--- a/target/ast10x0/peripherals/sgpiom/register_block.rs
+++ b/target/ast10x0/peripherals/sgpiom/register_block.rs
@@ -48,11 +48,36 @@ impl Sgpiom {
         unsafe { &*self.sgpiom }
     }
 
+    /// Read the global configuration register (`gpio554`) back from hardware.
+    #[must_use]
+    pub fn read_config(&self) -> u32 {
+        self.regs().gpio554().read().bits()
+    }
+
+    /// Dump the live SGPIOM register state for a bank via `pw_log::info!`.
+    ///
+    /// All values are read back from hardware (not the last written value), so
+    /// this confirms whether writes actually stuck and the engine reflects them.
+    pub fn debug_dump(&self, bank: Bank) {
+        pw_log::info!(
+            "sgpiom dump bank={} cfg(554)=0x{:08x} data(500)=0x{:08x} latch=0x{:08x} int_en=0x{:08x} int_sts=0x{:08x}",
+            bank as u32,
+            self.read_config() as u32,
+            self.port_get_raw(bank) as u32,
+            self.read_output_latch(bank) as u32,
+            self.int_en_read(bank) as u32,
+            self.interrupt_status(bank) as u32
+        );
+    }
+
     /// Configures SGPIOM global settings.
     ///
     /// `ngpios` is total SGPIO count across banks.
     pub fn configure_global(&self, ngpios: u16, clock_div: u16) -> Result<(), Error> {
-        if ngpios == 0 {
+        // Four 32-pin banks (A-P) => 128 max. Zephyr's AST10x0 DTS uses
+        // ngpios = 128; reject out-of-range instead of silently masking the
+        // 5-bit `numbers` hardware field.
+        if ngpios == 0 || ngpios > 128 {
             return Err(Error::InvalidNgpios);
         }
 
@@ -69,7 +94,10 @@ impl Sgpiom {
         Ok(())
     }
 
-    /// Read the raw 32-bit output register for a bank.
+    /// Read the raw 32-bit Data Value register for a bank.
+    ///
+    /// This returns the SGPIOM sampled *input* state, NOT the last value driven
+    /// out. For read-modify-write of outputs use [`Self::read_output_latch`].
     #[must_use]
     pub fn port_get_raw(&self, bank: Bank) -> u32 {
         match bank {
@@ -80,8 +108,36 @@ impl Sgpiom {
         }
     }
 
+    /// Read the output-latch readback register for a bank.
+    ///
+    /// The Data Value register (`port_get_raw`) returns the sampled *input*
+    /// state, not the value last driven out. For read-modify-write of outputs
+    /// we must read the dedicated Data Read (output-latch) register so that
+    /// untouched bits retain their previously driven value rather than being
+    /// overwritten with input samples.
+    ///
+    /// Bank `Mp` (M/N/O/P) has no `gpio57c()` accessor in the PAC, so its latch
+    /// readback (`wr_latch[3]` in Zephyr, controller base + 0x7c) is read raw to
+    /// stay aligned with the Zephyr RMW across all four banks.
+    #[must_use]
+    pub fn read_output_latch(&self, bank: Bank) -> u32 {
+        match bank {
+            Bank::Ad => self.regs().gpio570().read().bits(),
+            Bank::Eh => self.regs().gpio574().read().bits(),
+            Bank::Il => self.regs().gpio578().read().bits(),
+            // SAFETY: `self.sgpiom` is a valid RegisterBlock pointer (construction
+            // contract). The register block base is the controller base (0x..0500);
+            // +0x7c (= 0x..057c) is the MP write-latch readback, inside the mapped
+            // 0x100 SGPIOM register file.
+            Bank::Mp => unsafe {
+                let base = self.sgpiom.cast::<u8>();
+                core::ptr::read_volatile(base.add(0x7c).cast::<u32>())
+            },
+        }
+    }
+
     pub fn port_set_masked_raw(&self, bank: Bank, mask: u32, value: u32) {
-        let current = self.port_get_raw(bank);
+        let current = self.read_output_latch(bank);
         let next = (current & !mask) | (value & mask);
         self.port_write_raw(bank, next);
     }
@@ -95,7 +151,7 @@ impl Sgpiom {
     }
 
     pub fn port_toggle_bits(&self, bank: Bank, mask: u32) {
-        let current = self.port_get_raw(bank);
+        let current = self.read_output_latch(bank);
         self.port_write_raw(bank, current ^ mask);
     }
 
@@ -132,18 +188,16 @@ impl Sgpiom {
         Ok(())
     }
 
-    pub fn configure_interrupt(
-        &self,
-        dev: &BankDevice,
-        pin: u8,
+    /// Map a (`mode`, `trig`) pair to the 3-bit SGPIOM sensitivity-type code.
+    ///
+    /// Returns `Ok(None)` for [`InterruptMode::Disabled`] (no sensitivity to
+    /// program) and `Err(UnsupportedFlags)` for invalid combinations.
+    fn interrupt_sens_type(
         mode: InterruptMode,
         trig: InterruptTrigger,
-    ) -> Result<(), Error> {
-        dev.validate_pin(pin)?;
-
-        let bit = 1u32 << pin;
+    ) -> Result<Option<u8>, Error> {
         let int_type = match mode {
-            InterruptMode::Disabled => 0u8,
+            InterruptMode::Disabled => return Ok(None),
             InterruptMode::Level => match trig {
                 InterruptTrigger::Low => 2,
                 InterruptTrigger::High => 3,
@@ -155,37 +209,90 @@ impl Sgpiom {
                 InterruptTrigger::Both => 4,
             },
         };
+        Ok(Some(int_type))
+    }
 
-        match mode {
-            InterruptMode::Disabled => {
+    /// Write the 3-bit sensitivity code for a single `bit` into the bank's
+    /// `int_sens_type[0..2]` registers, leaving other pins untouched.
+    fn write_sens_bits(&self, bank: Bank, bit: u32, int_type: u8) {
+        let mut s0 = self.int_sens_read(bank, 0) & !bit;
+        let mut s1 = self.int_sens_read(bank, 1) & !bit;
+        let mut s2 = self.int_sens_read(bank, 2) & !bit;
+
+        if (int_type & 0x1) != 0 {
+            s0 |= bit;
+        }
+        if (int_type & 0x2) != 0 {
+            s1 |= bit;
+        }
+        if (int_type & 0x4) != 0 {
+            s2 |= bit;
+        }
+
+        self.int_sens_write(bank, 0, s0);
+        self.int_sens_write(bank, 1, s1);
+        self.int_sens_write(bank, 2, s2);
+    }
+
+    /// Configure a pin's interrupt sensitivity *and* enable/disable bit.
+    ///
+    /// For finer control (e.g. the HAL `GpioInterrupt` split of configure vs.
+    /// enable), see [`Self::configure_interrupt_sensitivity`] and
+    /// [`Self::set_interrupt_enable`].
+    pub fn configure_interrupt(
+        &self,
+        dev: &BankDevice,
+        pin: u8,
+        mode: InterruptMode,
+        trig: InterruptTrigger,
+    ) -> Result<(), Error> {
+        dev.validate_pin(pin)?;
+
+        let bit = 1u32 << pin;
+        match Self::interrupt_sens_type(mode, trig)? {
+            None => {
                 let en = self.int_en_read(dev.bank) & !bit;
                 self.int_en_write(dev.bank, en);
             }
-            _ => {
+            Some(int_type) => {
                 let en = self.int_en_read(dev.bank) | bit;
                 self.int_en_write(dev.bank, en);
-
-                let mut s0 = self.int_sens_read(dev.bank, 0) & !bit;
-                let mut s1 = self.int_sens_read(dev.bank, 1) & !bit;
-                let mut s2 = self.int_sens_read(dev.bank, 2) & !bit;
-
-                if (int_type & 0x1) != 0 {
-                    s0 |= bit;
-                }
-                if (int_type & 0x2) != 0 {
-                    s1 |= bit;
-                }
-                if (int_type & 0x4) != 0 {
-                    s2 |= bit;
-                }
-
-                self.int_sens_write(dev.bank, 0, s0);
-                self.int_sens_write(dev.bank, 1, s1);
-                self.int_sens_write(dev.bank, 2, s2);
+                self.write_sens_bits(dev.bank, bit, int_type);
             }
         }
 
         Ok(())
+    }
+
+    /// Program a pin's interrupt sensitivity only, without touching the enable
+    /// bit. Mirrors the EarlGrey `irq_configure` semantics where sensitivity
+    /// and enable are controlled independently.
+    pub fn configure_interrupt_sensitivity(
+        &self,
+        dev: &BankDevice,
+        pin: u8,
+        mode: InterruptMode,
+        trig: InterruptTrigger,
+    ) -> Result<(), Error> {
+        dev.validate_pin(pin)?;
+        let bit = 1u32 << pin;
+        // Disabled has no sensitivity to program; treat as code 0 (falling edge)
+        // which is inert while the enable bit stays clear.
+        let int_type = Self::interrupt_sens_type(mode, trig)?.unwrap_or(0);
+        self.write_sens_bits(dev.bank, bit, int_type);
+        Ok(())
+    }
+
+    /// Set the interrupt-enable bits for `mask` on a bank (OR into `int_en`).
+    pub fn set_interrupt_enable(&self, bank: Bank, mask: u32) {
+        let en = self.int_en_read(bank) | mask;
+        self.int_en_write(bank, en);
+    }
+
+    /// Clear the interrupt-enable bits for `mask` on a bank.
+    pub fn clear_interrupt_enable(&self, bank: Bank, mask: u32) {
+        let en = self.int_en_read(bank) & !mask;
+        self.int_en_write(bank, en);
     }
 
     /// Read the latched interrupt status register for a bank.

--- a/target/ast10x0/peripherals/sgpiom/types.rs
+++ b/target/ast10x0/peripherals/sgpiom/types.rs
@@ -70,24 +70,77 @@ pub struct BankDevice {
     pub bank: Bank,
     pub pin_offset: u8,
     pub ngpios: u8,
+    /// Bitmask of pins reserved/unusable within this bank (Zephyr `gpio-reserved`).
+    /// A set bit is excluded from [`Self::valid_mask`] and rejected by
+    /// [`Self::validate_pin`] / [`Self::validate_mask`].
+    pub reserved: u32,
 }
 
 impl BankDevice {
+    /// The only constructor: derives the bank from `pin_offset` (`pin_offset >> 5`,
+    /// the same mapping Zephyr uses) so the bank and offset can never disagree.
+    ///
+    /// Returns `None` unless `pin_offset` is one of `{0, 32, 64, 96}` (a 32-pin
+    /// bank boundary) and `ngpios` is in `1..=32`. This makes a mis-targeted
+    /// descriptor unrepresentable rather than relying on a debug assertion.
     #[inline]
-    pub const fn new(bank: Bank, pin_offset: u8, ngpios: u8) -> Self {
-        Self {
-            bank,
-            pin_offset,
-            ngpios,
+    pub const fn from_pin_offset(pin_offset: u8, ngpios: u8) -> Option<Self> {
+        // Must land exactly on a bank boundary; `pin_offset >> 5` alone would
+        // accept e.g. 33 (-> Eh) which is not a valid bank offset.
+        if pin_offset % 32 != 0 || ngpios == 0 || ngpios > 32 {
+            return None;
         }
+        match Bank::from_pin_offset(pin_offset) {
+            Some(bank) => Some(Self {
+                bank,
+                pin_offset,
+                ngpios,
+                reserved: 0,
+            }),
+            None => None,
+        }
+    }
+
+    /// Set the reserved-pin bitmask (builder), mirroring Zephyr `gpio-reserved`.
+    #[inline]
+    #[must_use]
+    pub const fn with_reserved(mut self, reserved: u32) -> Self {
+        self.reserved = reserved;
+        self
     }
 
     #[inline]
     pub fn validate_pin(&self, pin: u8) -> Result<(), Error> {
-        if pin < self.ngpios && pin < 32 {
+        if pin < self.ngpios && pin < 32 && (self.reserved & (1u32 << pin)) == 0 {
             Ok(())
         } else {
             Err(Error::InvalidPin)
+        }
+    }
+
+    /// Bitmask of the pins usable on this bank (`pin < ngpios`, capped at 32,
+    /// minus reserved pins).
+    ///
+    /// Mirrors Zephyr's per-child `port_pin_mask` (which folds in `gpio-reserved`).
+    #[inline]
+    #[must_use]
+    pub const fn valid_mask(&self) -> u32 {
+        let window = if self.ngpios >= 32 {
+            u32::MAX
+        } else {
+            (1u32 << self.ngpios) - 1
+        };
+        window & !self.reserved
+    }
+
+    /// Reject any mask bit outside this bank's usable window (out-of-range or
+    /// reserved).
+    #[inline]
+    pub fn validate_mask(&self, mask: u32) -> Result<(), Error> {
+        if (mask & !self.valid_mask()) != 0 {
+            Err(Error::InvalidPin)
+        } else {
+            Ok(())
         }
     }
 }

--- a/target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq/BUILD.bazel
+++ b/target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq/BUILD.bazel
@@ -1,0 +1,95 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:rust_app.bzl", "rust_app")
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image", "system_image_test")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@pigweed//pw_kernel/tooling/panic_detector:rust_binary_no_panics_test.bzl", "rust_binary_no_panics_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/ast10x0:defs.bzl", "TARGET_COMPATIBLE_WITH")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/arm_cortex_m:arch_arm_cortex_m",
+    system_config = ":system_config",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    template = "//target/ast10x0:linker_script_template",
+)
+
+rust_binary(
+    name = "target",
+    srcs = ["target.rs"],
+    edition = "2024",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/ast10x0:entry",
+        "//target/ast10x0/peripherals",
+        "@pigweed//pw_kernel/arch/arm_cortex_m:arch_arm_cortex_m",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_kernel/userspace",
+    ],
+)
+
+rust_app(
+    name = "sgpiom_irq_server",
+    srcs = ["sgpiom_irq_server_main.rs"],
+    codegen_crate_name = "app_sgpiom_irq_server",
+    edition = "2024",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        "//hal/blocking",
+        "//target/ast10x0/peripherals",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+        "@pigweed//pw_status/rust:pw_status",
+    ],
+)
+
+system_image(
+    name = "sgpiom_irq",
+    apps = [
+        ":sgpiom_irq_server",
+    ],
+    kernel = ":target",
+    platform = "//target/ast10x0",
+    system_config = ":system_config",
+    tags = ["kernel"],
+)
+
+system_image_test(
+    name = "sgpiom_irq_test",
+    image = ":sgpiom_irq",
+    tags = ["hardware"],
+    target_compatible_with = select({
+        "//target/ast10x0:qemu_enabled": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)
+
+rust_binary_no_panics_test(
+    name = "no_panics_test",
+    binary = ":sgpiom_irq",
+    tags = ["kernel"],
+)

--- a/target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq/README.md
+++ b/target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq/README.md
@@ -1,0 +1,77 @@
+<!-- Licensed under the Apache-2.0 license -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# AST10x0 SGPIOM Interrupt Bring-up (`sgpiom_irq`)
+
+Real-hardware test image that exercises the SGPIOM interrupt path end-to-end
+through the OpenPRoT microkernel **wait-on-object** model — the same model the
+EarlGrey GPIO driver documents, where interrupts are delivered to userspace via
+syscalls rather than in-driver ISR callbacks.
+
+This is **not** a QEMU test: `sgpiom_irq_test` is tagged `hardware` and is marked
+incompatible when `qemu_enabled`. It must run on a real AST1060 board.
+
+## What it does
+
+A single userspace app (`sgpiom_irq_server`):
+
+1. Owns the SGPIOM register block (device mapping `sgpiom_regs` @ `0x7e780500`).
+2. Programs both-edge sensitivity on a watched SGPIO input mask via the HAL
+   `GpioInterrupt::irq_configure`.
+3. Registers the SGPIOM interrupt object (**IRQ 51**, `INTR_SGPIOM`) with a wait
+   group, then enables the pins via `GpioInterrupt::irq_control(Enable)` and
+   unmasks the line at the kernel with `interrupt_ack`.
+4. Blocks on `object_wait(WG, signals::SGPIOM)`. On each wakeup it reads the
+   latched interrupt-status register, clears it (`irq_control(Clear)`), and
+   re-arms delivery.
+5. After `EXPECTED_EDGES` wakeups it shuts down **PASS**; if the wait budget
+   (`WAIT_BUDGET_MS`) elapses first it shuts down **FAIL**.
+
+Console sentinels: `TEST_RESULT:PASS` / `TEST_RESULT:FAIL` (emitted by the
+kernel `Target::shutdown`).
+
+## Pin mux
+
+The kernel applies `pinctrl::PINCTRL_SGPIOM` at boot (SCU41C[8:11]):
+
+| pin       | SCU41C bit | function          |
+|-----------|------------|-------------------|
+| `sgpmclk` | 8          | serial clock out  |
+| `sgpmld`  | 9          | load/latch out    |
+| `sgpmo`   | 10         | serial data out   |
+| `sgpmi`   | 11         | serial data in    |
+
+SGPIOM is clocked by PCLK (always running), so no clock ungate or controller
+reset is performed.
+
+## External stimulus (REQUIRED)
+
+SGPIOM samples external serial GPIO **inputs**; an interrupt fires only when a
+watched input bit changes. A bare board produces no edges, so the test will
+time out **FAIL** without stimulus.
+
+Drive the watched SGPIO_A input bits externally — e.g. a second board acting as
+an SGPIO source, or the input shift-register chain wired to the SGPIOM serial
+pins (`sgpmclk`/`sgpmld`/`sgpmo`/`sgpmi`). This mirrors the two-board harness
+model of the I2C IRQ master/slave test (`tests/peripherals/i2c/i2c_irq`).
+
+Watched mask: bank A, pins `0..=3` (`WATCH_MASK = 0x0f`); both edges count.
+
+## Build / run
+
+```
+bazel build //target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq:sgpiom_irq
+bazel test  //target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq:sgpiom_irq_test   # hardware only
+bazel test  //target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq:no_panics_test
+```
+
+## Tunables (`sgpiom_irq_server_main.rs`)
+
+| const             | meaning                                  |
+|-------------------|------------------------------------------|
+| `NGPIOS`          | total SGPIO count in the global config   |
+| `CLOCK_DIV`       | serial clock divider                     |
+| `WATCH_MASK`      | which bank-A pins to watch                |
+| `EXPECTED_EDGES`  | wakeups required for PASS                 |
+| `POLL_MS`         | per-`object_wait` timeout                |
+| `WAIT_BUDGET_MS`  | total wait before FAIL                    |

--- a/target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq/sgpiom_irq_server_main.rs
+++ b/target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq/sgpiom_irq_server_main.rs
@@ -1,0 +1,222 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! SGPIOM combined output + interrupt test (single process, userspace, ONE image).
+//!
+//! Does everything in one continuous loop:
+//!   - OUTPUT: blinks SGPIO_A pins 0..7 (LEDs) high/low each tick (0xff <-> 0x00).
+//!   - INPUT/IRQ: arms both-edge interrupts on the watched input mask via the HAL
+//!     [`GpioInterrupt`] trait and reports each edge. Interrupts are delivered to
+//!     userspace via the microkernel wait-on-object model (`object_wait`), not via
+//!     in-driver ISR callbacks (`register_interrupt_handler` is unsupported).
+//!
+//! Config matches Zephyr's live SGPIOM state (ngpios=128 -> numbers=16, clock
+//! divider 24) so the full serial daisy chain is clocked.
+
+#![no_main]
+#![no_std]
+
+use app_sgpiom_irq_server::{handle, signals};
+use ast10x0_peripherals::sgpiom::{Bank, BankDevice, Sgpiom, SgpiomBankPort, SgpiomMask};
+use openprot_hal_blocking::gpio_port::{
+    ActivePolarity, EdgeSensitivity, GpioInterrupt, GpioPort, InterruptOperation, PinConfig,
+    PinDirection,
+};
+use pw_status::Error;
+use userspace::entry;
+use userspace::syscall;
+use userspace::time::Duration;
+
+/// Controller total SGPIO count (Zephyr DTS uses 128 -> numbers = 16 bytes).
+const NGPIOS: u16 = 128;
+/// Per-bank pin count for the descriptor (bank max 32).
+const BANK_NGPIOS: u8 = 32;
+/// Serial clock divider (matches Zephyr live config 0x554 division = 24).
+const CLOCK_DIV: u16 = 24;
+/// Output pins: SGPIO_A 0..7 (the LEDs).
+const OUT_MASK: u32 = 0x0000_00ff;
+/// Static output pattern, pins 0..7 = 1,0,1,0,... (A0/A2/A4/A6 high).
+const OUT_PATTERN: u32 = 0x0000_0055;
+/// Watched input pins for interrupts (SGPIO_A 0..7).
+const WATCH_MASK: u32 = 0x0000_00ff;
+/// Input-poll cadence (re-check, not a FAIL timeout).
+const POLL_MS: i64 = 500;
+
+macro_rules! fail {
+    ($($arg:tt)*) => {{
+        pw_log::error!($($arg)*);
+        let _ = syscall::debug_shutdown(Err(Error::Unknown));
+        #[expect(clippy::empty_loop)]
+        loop {}
+    }};
+}
+
+#[entry]
+fn entry() {
+    // SAFETY: this process exclusively owns the SGPIOM device region mapped in
+    // system.json5 (`sgpiom_regs`); `new_global` points at 0x7e780500.
+    let sgpiom = unsafe { Sgpiom::new_global() };
+    if sgpiom.configure_global(NGPIOS, CLOCK_DIV).is_err() {
+        fail!("configure_global failed");
+    }
+
+    // Second handle (read-only register dumps / status reads).
+    // SAFETY: same device region; reads are side-effect free.
+    let monitor = unsafe { Sgpiom::new_global() };
+
+    let Some(dev) = BankDevice::from_pin_offset(0, BANK_NGPIOS) else {
+        fail!("invalid BankDevice descriptor");
+    };
+    // SAFETY: same ownership contract as `Sgpiom::new`.
+    let mut port = unsafe { SgpiomBankPort::new(sgpiom, dev) };
+
+    // OUTPUT: mark the blink pins as outputs (direction is HW-managed; validates mask).
+    if port
+        .configure(
+            SgpiomMask(OUT_MASK),
+            PinConfig {
+                direction: PinDirection::Output,
+                polarity: ActivePolarity::ActiveHigh,
+                initial_output: None,
+            },
+        )
+        .is_err()
+    {
+        fail!("configure (output) failed");
+    }
+
+    // OUTPUT: drive the static 1,0,1,0... pattern (0x55) once — set even pins,
+    // reset odd pins within the output mask. Held for the rest of the run.
+    if port
+        .set_reset(SgpiomMask(OUT_PATTERN), SgpiomMask(OUT_MASK & !OUT_PATTERN))
+        .is_err()
+    {
+        fail!("set_reset (output) failed");
+    }
+
+    // INPUT: read back the input state once output is driven, before arming IRQ.
+    // SGPIO samples inputs serially over the daisy chain (clock divider 24), so
+    // the data register is only valid after a full scan completes; the first
+    // read after `configure_global` lands mid-scan and returns the reset value
+    // (0). The HW serial engine runs independently of this thread, so a short
+    // busy-wait on the monotonic clock lets it settle. (`sleep_until` returns
+    // early here, so it does not actually delay.)
+    busy_wait_ms(50);
+    // Decode each watched pin so it's human-readable, not just a hex word.
+    let data = monitor.port_get_raw(Bank::Ad);
+    pw_log::info!("SGPIO input: data=0x{:08x}", data as u32);
+    let mut watch = WATCH_MASK;
+    while watch != 0 {
+        let pin = watch.trailing_zeros();
+        watch &= watch - 1;
+        pw_log::info!(
+            "  SGPIO_{}{} (pin {}) level={}",
+            group_letter(pin) as &str,
+            (pin % 8) as u32,
+            pin as u32,
+            ((data >> pin) & 1) as u32
+        );
+    }
+    monitor.debug_dump(Bank::Ad);
+
+    // INPUT/IRQ: both-edge sensitivity on the watched pins.
+    if port
+        .irq_configure(SgpiomMask(WATCH_MASK), EdgeSensitivity::BothEdges)
+        .is_err()
+    {
+        fail!("irq_configure failed");
+    }
+
+    // Register the IRQ object with the wait group BEFORE enabling delivery.
+    if syscall::wait_group_add(
+        handle::WG,
+        handle::SGPIOM_IRQ,
+        signals::SGPIOM,
+        handle::SGPIOM_IRQ as usize,
+    )
+    .is_err()
+    {
+        fail!("wait_group_add failed");
+    }
+
+    if port.irq_control(SgpiomMask(WATCH_MASK), InterruptOperation::Enable) != Ok(true) {
+        fail!("irq enable failed");
+    }
+    if syscall::interrupt_ack(handle::SGPIOM_IRQ, signals::SGPIOM).is_err() {
+        fail!("initial interrupt_ack failed");
+    }
+
+    pw_log::info!(
+        "SGPIOM monitoring IRQ: out pins0..7=0x{:02x}, watch in=0x{:08x}",
+        OUT_PATTERN as u32,
+        WATCH_MASK as u32
+    );
+
+    // Loop: report input edges. object_wait blocks until an IRQ is delivered or
+    // the re-check deadline (not a FAIL timeout). The output pattern stays held.
+    //
+    // `interrupt_status` only tells WHICH pin edged, not the direction. For
+    // both-edge sensitivity we infer rising/falling by diffing against the last
+    // observed level snapshot. A latched edge whose level matches the snapshot
+    // (logged `unchanged`) means the pin toggled and returned between scans —
+    // expected with serial-sampled SGPIO, not a bug.
+    let poll = Duration::from_millis(POLL_MS);
+    let mut prev = data;
+    loop {
+        let deadline = syscall::debug_clock_now() + poll;
+        let _ = syscall::object_wait(handle::WG, signals::SGPIOM, deadline);
+
+        let status = monitor.interrupt_status(Bank::Ad) & WATCH_MASK;
+        if status != 0 {
+            let now = monitor.port_get_raw(Bank::Ad);
+            // Decode each set status bit to a concrete pin so it's human-readable.
+            let mut bits = status;
+            while bits != 0 {
+                let pin = bits.trailing_zeros();
+                bits &= bits - 1;
+                let old = (prev >> pin) & 1;
+                let new = (now >> pin) & 1;
+                let edge: &str = if new > old {
+                    "rising 0->1"
+                } else if new < old {
+                    "falling 1->0"
+                } else {
+                    "unchanged (toggled between scans)"
+                };
+                pw_log::info!(
+                    "SGPIO edge: SGPIO_{}{} (pin {}) {}",
+                    group_letter(pin) as &str,
+                    (pin % 8) as u32,
+                    pin as u32,
+                    edge as &str
+                );
+            }
+            prev = now;
+            let _ = port.irq_control(SgpiomMask(status), InterruptOperation::Clear);
+        }
+        let _ = syscall::interrupt_ack(handle::SGPIOM_IRQ, signals::SGPIOM);
+    }
+}
+
+/// Busy-wait `ms` milliseconds on the monotonic clock. Unlike `sleep_until`,
+/// this does not rely on `object_wait` (which returns early on this target), so
+/// it gives the HW SGPIO serial scan real wall-clock time to settle.
+fn busy_wait_ms(ms: i64) {
+    let until = syscall::debug_clock_now() + Duration::from_millis(ms);
+    while syscall::debug_clock_now() < until {}
+}
+
+/// SGPIO group letter for a bank-Ad pin index (A=0..7, B=8..15, C=16..23, D=24..31).
+fn group_letter(pin: u32) -> &'static str {
+    match pin / 8 {
+        0 => "A",
+        1 => "B",
+        2 => "C",
+        _ => "D",
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq/system.json5
+++ b/target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq/system.json5
@@ -1,0 +1,88 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+// AST10x0 SGPIOM interrupt bring-up image.
+//
+// Single userspace app (`sgpiom_irq_server`) that:
+//   - owns the SGPIOM device register block (0x7e780500),
+//   - arms both-edge interrupts on a watched SGPIO input mask via the HAL
+//     `GpioInterrupt` trait,
+//   - waits on the SGPIOM interrupt object (IRQ 51) through a wait group, the
+//     OpenPRoT microkernel wait-on-object model (no in-driver ISR callbacks).
+//
+// SGPIO input edges are driven EXTERNALLY (signal source / second board), the
+// same harness model as the I2C IRQ master/slave test — see README.md.
+//
+// PMSAv7-friendly memory layout (mirrors the USART server image):
+//   0x00000000 - 0x00000800: Vector table (2048 bytes, 512 vectors)
+//   0x00000800 - 0x00008800: Kernel code (32KB; ~30KB used)
+//   0x00008800 - 0x00010800: app flash (32KB; app code is ~4KB)
+//   0x00060000 - 0x00080000: Kernel RAM (128KB)
+//   0x00080000 - 0x00090000: App RAM (64KB)
+//
+// The flat boot .bin spans flash 0 to the app code, so the kernel flash budget
+// (not app size) dominates upload size: shrinking kernel flash moves the app
+// down and removes the inter-region zero padding (was 126KB -> ~135KB .bin).
+{
+    arch: {
+        type: "armv7m",
+        vector_table_start_address: 0x00000000,
+        vector_table_size_bytes: 2048,  // 0x800 (512 vectors)
+    },
+    kernel: {
+        flash_start_address: 0x00000800,  // After vector table
+        // 0x7800 so the kernel flash ends exactly at 0x8000 — a PMSAv7 MPU
+        // 16KB subregion boundary — and the app starts there without the
+        // subregion-overlap warning. Kernel code is ~30KB.
+        flash_size_bytes: 30720,          // 0x7800 (0x800..0x8000)
+        ram_start_address: 0x00060000,
+        ram_size_bytes: 131072,           // 128KB
+    },
+    apps: [
+        {
+            name: "sgpiom_irq_server",
+            flash_size_bytes: 32768,      // 32KB (app code ~4KB)
+            processes: [
+                {
+                    name: "sgpiom_irq_process",
+                    ram_size_bytes: 65536,        // 64KB
+                    objects: [
+                        {
+                            name: "wg",
+                            type: "wait_group",
+                        },
+                        {
+                            // AST1060 SGPIOM interrupt line.
+                            // Source: ast1060_pac::Interrupt::sgpiom = 51
+                            //         (Zephyr INTR_SGPIOM = 51).
+                            name: "sgpiom_irq",
+                            type: "interrupt",
+                            irqs: [
+                                {
+                                    name: "sgpiom",
+                                    number: 51,
+                                },
+                            ],
+                        },
+                    ],
+                    memory_mappings: [
+                        {
+                            // AST1060 GPIO/SGPIO controller block; the SGPIOM
+                            // register file lives at 0x7e780500 (reg 0x100).
+                            name: "sgpiom_regs",
+                            type: "device",
+                            start_address: 0x7e780000,
+                            size_bytes: 0x1000,
+                        },
+                    ],
+                    threads: [
+                        {
+                            name: "sgpiom_irq_thread",
+                            kernel_stack_size_bytes: 4096,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+}

--- a/target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq/target.rs
+++ b/target/ast10x0/tests/peripherals/sgpiom/sgpiom_irq/target.rs
@@ -1,0 +1,52 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! AST10x0 SGPIOM interrupt bring-up — kernel side.
+//!
+//! Performs kernel-owned early platform init for the SGPIOM userspace app:
+//! applies the SGPIOM pin mux (SCU41C[8:11]). SGPIOM is clocked by PCLK, which
+//! is already running, so no clock ungate or controller reset is needed (the
+//! Zephyr driver likewise only reads PCLK to compute the serial divider).
+//!
+//! All interrupt handling happens in userspace via the wait-on-object syscall
+//! model (see `sgpiom_irq_server_main.rs`); the kernel only brings up pins and
+//! starts the apps.
+
+#![no_std]
+#![no_main]
+
+use ast10x0_peripherals::scu::{pinctrl, ScuRegisters};
+use console_backend::console_backend_write_all;
+use entry as _;
+use target_common::{declare_target, TargetInterface};
+
+pub struct Target {}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "AST10x0 SGPIOM IRQ Bringup";
+
+    fn main() -> ! {
+        // SAFETY: single call at boot with exclusive access to SCU global regs.
+        unsafe {
+            let scu = ScuRegisters::new_global_unlocked();
+            scu.apply_pinctrl_group(pinctrl::PINCTRL_SGPIOM);
+        }
+
+        codegen::start();
+        #[expect(clippy::empty_loop)]
+        loop {}
+    }
+
+    fn shutdown(code: u32) -> ! {
+        let sentinel: &[u8] = if code == 0 {
+            b"TEST_RESULT:PASS\n"
+        } else {
+            b"TEST_RESULT:FAIL\n"
+        };
+        let _ = console_backend_write_all(sentinel);
+        #[expect(clippy::empty_loop)]
+        loop {}
+    }
+}
+
+declare_target!(Target);

--- a/target/ast10x0/tests/peripherals/sgpiom/sgpiom_smoke/target.rs
+++ b/target/ast10x0/tests/peripherals/sgpiom/sgpiom_smoke/target.rs
@@ -10,7 +10,8 @@ use ast10x0_peripherals::sgpiom::{
 };
 use console_backend::console_backend_write_all;
 use openprot_hal_blocking::gpio_port::{
-    ActivePolarity, GpioBankPassthrough, GpioPort, PinConfig, PinDirection,
+    ActivePolarity, EdgeSensitivity, GpioBankPassthrough, GpioInterrupt, GpioPort,
+    InterruptOperation, PinConfig, PinDirection,
 };
 use target_common::{declare_target, TargetInterface};
 use {codegen as _, entry as _};
@@ -41,7 +42,13 @@ fn run_smoke_test() -> bool {
         return false;
     }
 
-    let dev = BankDevice::new(Bank::Ad, 0, 16);
+    let dev = match BankDevice::from_pin_offset(0, 16) {
+        Some(d) => d,
+        None => {
+            pw_log::error!("invalid BankDevice descriptor");
+            return false;
+        }
+    };
 
     if sgpiom
         .configure_pin(
@@ -60,7 +67,9 @@ fn run_smoke_test() -> bool {
         return false;
     }
 
-    if (sgpiom.port_get_raw(Bank::Ad) & (1 << 1)) == 0 {
+    // Verify the driven output via the output-latch readback, not port_get_raw
+    // (the Data Value register reads sampled *input*, not the last driven value).
+    if (sgpiom.read_output_latch(Bank::Ad) & (1 << 1)) == 0 {
         pw_log::error!("configure_pin did not set pin high");
         return false;
     }
@@ -130,6 +139,15 @@ fn run_smoke_test() -> bool {
         return false;
     }
 
+    // Verify the driven output via the output-latch readback (not port_get_raw,
+    // which reads sampled input). set_reset drove bit5 high / bit3 low. Checked
+    // here BEFORE passthrough, which would overwrite bit5 with sampled input.
+    let latched = sgpiom.read_output_latch(Bank::Ad);
+    if (latched & (1 << 5)) == 0 || (latched & (1 << 3)) != 0 {
+        pw_log::error!("HAL operations produced unexpected output state");
+        return false;
+    }
+
     if bank_port.set_passthrough_mask(SgpiomMask(1 << 5)).is_err() {
         pw_log::error!("HAL passthrough failed");
         return false;
@@ -140,16 +158,61 @@ fn run_smoke_test() -> bool {
         return false;
     }
 
-    let observed = match bank_port.read_input() {
-        Ok(v) => v.0,
-        Err(_) => {
-            pw_log::error!("HAL read_input failed");
-            return false;
-        }
-    };
+    // HAL GpioInterrupt: configure sensitivity, then enable/query/clear/disable.
+    let irq_mask = SgpiomMask(1 << 6);
+    if bank_port.irq_configure(irq_mask, EdgeSensitivity::RisingEdge).is_err() {
+        pw_log::error!("HAL irq_configure failed");
+        return false;
+    }
+    // RisingEdge => Edge+High => sens code 1 => sens0 set, sens1/sens2 clear.
+    let s0 = regs.gpio508().read().bits();
+    let s1 = regs.gpio50c().read().bits();
+    let s2 = regs.gpio510().read().bits();
+    if (s0 & (1 << 6)) == 0 || (s1 & (1 << 6)) != 0 || (s2 & (1 << 6)) != 0 {
+        pw_log::error!("HAL irq_configure sensitivity mismatch");
+        return false;
+    }
 
-    if (observed & (1 << 5)) == 0 || (observed & (1 << 3)) != 0 {
-        pw_log::error!("HAL operations produced unexpected output state");
+    if bank_port.irq_control(irq_mask, InterruptOperation::Enable) != Ok(true) {
+        pw_log::error!("HAL irq enable failed");
+        return false;
+    }
+    if (regs.gpio504().read().bits() & (1 << 6)) == 0 {
+        pw_log::error!("HAL irq enable did not set int_en");
+        return false;
+    }
+
+    // IsPending must not error (status value is environment-dependent).
+    if bank_port.irq_control(irq_mask, InterruptOperation::IsPending).is_err() {
+        pw_log::error!("HAL irq IsPending failed");
+        return false;
+    }
+    if bank_port.irq_control(irq_mask, InterruptOperation::Clear) != Ok(true) {
+        pw_log::error!("HAL irq clear failed");
+        return false;
+    }
+    if bank_port.irq_control(irq_mask, InterruptOperation::Disable) != Ok(true) {
+        pw_log::error!("HAL irq disable failed");
+        return false;
+    }
+    if (regs.gpio504().read().bits() & (1 << 6)) != 0 {
+        pw_log::error!("HAL irq disable did not clear int_en");
+        return false;
+    }
+
+    // Callback registration is unsupported in the microkernel model.
+    if bank_port
+        .register_interrupt_handler(irq_mask, |_m: SgpiomMask| {})
+        .is_ok()
+    {
+        pw_log::error!("HAL register_interrupt_handler unexpectedly succeeded");
+        return false;
+    }
+
+    // Exercise the read_input HAL path (returns sampled input; value is
+    // environment-dependent, so only check it does not error).
+    if bank_port.read_input().is_err() {
+        pw_log::error!("HAL read_input failed");
         return false;
     }
 

--- a/tools/sgpiom/examples/common.json
+++ b/tools/sgpiom/examples/common.json
@@ -2,7 +2,7 @@
   "board": "common",
   "controller": {
     "name": "sgpiom0",
-    "base_addr": "0x1E780000",
+    "base_addr": "0x7E780500",
     "bus_frequency_hz": 1000000,
     "ngpios": 128,
     "enabled": true

--- a/tools/sgpiom/schema/banks.schema.json
+++ b/tools/sgpiom/schema/banks.schema.json
@@ -8,7 +8,7 @@
     "required": ["name", "pin_offset", "ngpios", "reserved_pins"],
     "properties": {
       "name": { "type": "string", "minLength": 1 },
-      "pin_offset": { "type": "integer", "minimum": 0 },
+      "pin_offset": { "type": "integer", "enum": [0, 32, 64, 96] },
       "ngpios": { "type": "integer", "minimum": 1, "maximum": 32 },
       "reserved_pins": {
         "type": "array",

--- a/tools/sgpiom/schema/controller.schema.json
+++ b/tools/sgpiom/schema/controller.schema.json
@@ -8,12 +8,12 @@
     "name": { "type": "string", "minLength": 1 },
     "base_addr": {
       "oneOf": [
-        { "type": "integer", "minimum": 0 },
-        { "type": "string", "pattern": "^0x[0-9a-fA-F]+$" }
+        { "type": "integer", "minimum": 0, "maximum": 4294967295 },
+        { "type": "string", "pattern": "^0x[0-9a-fA-F]{1,8}$" }
       ]
     },
-    "bus_frequency_hz": { "type": "integer", "minimum": 0 },
-    "ngpios": { "type": "integer", "minimum": 1 },
+    "bus_frequency_hz": { "type": "integer", "minimum": 0, "maximum": 4294967295 },
+    "ngpios": { "type": "integer", "minimum": 1, "maximum": 128 },
     "enabled": { "type": "boolean" }
   },
   "additionalProperties": true

--- a/tools/sgpiom/sgpio_json_tool.py
+++ b/tools/sgpiom/sgpio_json_tool.py
@@ -110,7 +110,8 @@ def merge_manifests(inputs: Iterable[JsonMap]) -> JsonMap:
 
 
 def _is_nonneg_int(value: Any) -> bool:
-    return isinstance(value, int) and value >= 0
+    # `bool` is a subclass of `int`; exclude it so `true`/`false` are rejected.
+    return type(value) is int and value >= 0
 
 
 def _is_bool(value: Any) -> bool:
@@ -118,7 +119,43 @@ def _is_bool(value: Any) -> bool:
 
 
 def _is_hex_string(value: Any) -> bool:
-    return isinstance(value, str) and value.startswith("0x")
+    # Lowercase `0x` prefix only, to match the schema pattern and keep a single
+    # canonical form across schema-only and tool validation.
+    if not isinstance(value, str) or not value.startswith("0x"):
+        return False
+    try:
+        int(value, 16)
+        return True
+    except ValueError:
+        return False
+
+
+# Largest value representable by the generated `u32` fields.
+_U32_MAX = 0xFFFF_FFFF
+
+
+def _hex_or_int_value(value: Any) -> int:
+    """Numeric value of a hex-string or integer (callers pre-validate the type)."""
+    return int(value, 16) if isinstance(value, str) else int(value)
+
+
+def _rust_str_literal(value: str) -> str:
+    """Emit a `value` as an escaped Rust string literal (incl. surrounding quotes)."""
+    out = []
+    for ch in value:
+        if ch == "\\":
+            out.append("\\\\")
+        elif ch == '"':
+            out.append('\\"')
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\r":
+            out.append("\\r")
+        elif ch == "\t":
+            out.append("\\t")
+        else:
+            out.append(ch)
+    return '"' + "".join(out) + '"'
 
 
 def validate_manifest(manifest: JsonMap) -> ValidationResult:
@@ -151,14 +188,23 @@ def validate_manifest(manifest: JsonMap) -> ValidationResult:
         base_addr = controller["base_addr"]
         if not (_is_hex_string(base_addr) or _is_nonneg_int(base_addr)):
             errors.append("controller.base_addr: must be hex string or integer")
+        elif _hex_or_int_value(base_addr) > _U32_MAX:
+            errors.append("controller.base_addr: exceeds u32 range (> 0xffffffff)")
 
-    if "bus_frequency_hz" in controller and not _is_nonneg_int(
-        controller["bus_frequency_hz"]
+    if "bus_frequency_hz" in controller:
+        bus_freq = controller["bus_frequency_hz"]
+        if not _is_nonneg_int(bus_freq):
+            errors.append("controller.bus_frequency_hz: must be non-negative integer")
+        elif bus_freq > _U32_MAX:
+            errors.append("controller.bus_frequency_hz: exceeds u32 range (> 0xffffffff)")
+
+    if "ngpios" in controller and (
+        not _is_nonneg_int(controller["ngpios"])
+        or controller["ngpios"] == 0
+        or controller["ngpios"] > 128
     ):
-        errors.append("controller.bus_frequency_hz: must be non-negative integer")
-
-    if "ngpios" in controller and (not _is_nonneg_int(controller["ngpios"]) or controller["ngpios"] == 0):
-        errors.append("controller.ngpios: must be positive integer")
+        # Four 32-pin banks (A-P) => 128 max (matches Zephyr AST10x0 DTS).
+        errors.append("controller.ngpios: must be a positive integer <= 128")
 
     if "enabled" in controller and not _is_bool(controller["enabled"]):
         errors.append("controller.enabled: must be bool")
@@ -170,7 +216,9 @@ def validate_manifest(manifest: JsonMap) -> ValidationResult:
 
     bank_by_name: Dict[str, JsonMap] = {}
     seen_bank_names: set[str] = set()
+    seen_pin_offsets: set[int] = set()
     total_bank_gpios = 0
+    controller_ngpios = controller.get("ngpios")
 
     for i, bank in enumerate(banks):
         prefix = f"banks[{i}]"
@@ -194,12 +242,31 @@ def validate_manifest(manifest: JsonMap) -> ValidationResult:
         pin_offset = bank.get("pin_offset")
         if not _is_nonneg_int(pin_offset):
             errors.append(f"{prefix}.pin_offset: must be non-negative integer")
+        elif pin_offset not in (0, 32, 64, 96):
+            # Runtime derives the bank as pin_offset >> 5; only the four 32-pin
+            # bank boundaries are valid (Zephyr offsets 0/32/64/96).
+            errors.append(
+                f"{prefix}.pin_offset: must be one of 0, 32, 64, 96 (got {pin_offset})"
+            )
+        else:
+            if pin_offset in seen_pin_offsets:
+                errors.append(f"{prefix}.pin_offset: duplicate pin_offset {pin_offset}")
+            seen_pin_offsets.add(pin_offset)
 
         ngpios = bank.get("ngpios")
         if not _is_nonneg_int(ngpios) or ngpios == 0 or ngpios > 32:
             errors.append(f"{prefix}.ngpios: must be integer in range 1..32")
         else:
             total_bank_gpios += ngpios
+            if (
+                _is_nonneg_int(pin_offset)
+                and isinstance(controller_ngpios, int)
+                and pin_offset + ngpios > controller_ngpios
+            ):
+                errors.append(
+                    f"{prefix}: pin_offset + ngpios ({pin_offset} + {ngpios}) "
+                    f"exceeds controller.ngpios ({controller_ngpios})"
+                )
 
         reserved = bank.get("reserved_pins")
         if not isinstance(reserved, list):
@@ -213,7 +280,6 @@ def validate_manifest(manifest: JsonMap) -> ValidationResult:
                         f"{prefix}.reserved_pins[{j}]: pin {pin} out of range for ngpios {ngpios}"
                     )
 
-    controller_ngpios = controller.get("ngpios")
     if isinstance(controller_ngpios, int) and total_bank_gpios > controller_ngpios:
         errors.append(
             "controller.ngpios: smaller than sum of bank ngpios "
@@ -272,7 +338,8 @@ def validate_manifest(manifest: JsonMap) -> ValidationResult:
             errors.append(f"{prefix}.active_level: must be 'high' or 'low'")
 
         safe_default = signal.get("safe_default")
-        if safe_default not in (None, 0, 1):
+        # `bool` is an `int` subclass and true==1/false==0, so exclude it explicitly.
+        if not (safe_default is None or (type(safe_default) is int and safe_default in (0, 1))):
             errors.append(f"{prefix}.safe_default: must be null, 0, or 1")
 
         bank = bank_by_name.get(bank_name)
@@ -373,14 +440,11 @@ def render_rust(manifest: JsonMap) -> str:
     lines.append("}")
     lines.append("")
 
-    base_addr = controller["base_addr"]
-    if isinstance(base_addr, str):
-        base_addr_literal = base_addr
-    else:
-        base_addr_literal = hex(base_addr)
+    # Canonicalize to a lowercase `0x` Rust literal regardless of input form.
+    base_addr_literal = hex(_hex_or_int_value(controller["base_addr"]))
 
     lines.append("pub const SGPIOM_CONTROLLER: SgpiomControllerConfig = SgpiomControllerConfig {")
-    lines.append(f"    name: \"{controller['name']}\",")
+    lines.append(f"    name: {_rust_str_literal(controller['name'])},")
     lines.append(f"    base_addr: {base_addr_literal},")
     lines.append(f"    bus_frequency_hz: {controller['bus_frequency_hz']},")
     lines.append(f"    ngpios: {controller['ngpios']},")
@@ -388,22 +452,23 @@ def render_rust(manifest: JsonMap) -> str:
     lines.append("};")
     lines.append("")
 
-    for bank in banks:
-        ident = rust_ident(bank["name"])
+    # Index the const name (not rust_ident(name)) so distinct bank names that
+    # sanitize to the same identifier (e.g. "a-b" / "a_b") cannot collide into
+    # one RESERVED_PINS_* symbol.
+    for i, bank in enumerate(banks):
         reserved = ", ".join(str(pin) for pin in sorted(bank.get("reserved_pins", [])))
         lines.append(
-            f"const RESERVED_PINS_{ident}: [u8; {len(bank.get('reserved_pins', []))}] = [{reserved}];"
+            f"const RESERVED_PINS_{i}: [u8; {len(bank.get('reserved_pins', []))}] = [{reserved}];"
         )
     lines.append("")
 
     lines.append(f"pub const SGPIOM_BANKS: [SgpiomBankConfig; {len(banks)}] = [")
-    for bank in banks:
-        ident = rust_ident(bank["name"])
+    for i, bank in enumerate(banks):
         lines.append("    SgpiomBankConfig {")
-        lines.append(f"        name: \"{bank['name']}\",")
+        lines.append(f"        name: {_rust_str_literal(bank['name'])},")
         lines.append(f"        pin_offset: {bank['pin_offset']},")
         lines.append(f"        ngpios: {bank['ngpios']},")
-        lines.append(f"        reserved_pins: &RESERVED_PINS_{ident},")
+        lines.append(f"        reserved_pins: &RESERVED_PINS_{i},")
         lines.append("    },")
     lines.append("];\n")
 
@@ -420,8 +485,8 @@ def render_rust(manifest: JsonMap) -> str:
             safe_default_text = "Some(true)" if safe_default == 1 else "Some(false)"
 
         lines.append("    SgpiomSignalConfig {")
-        lines.append(f"        logical_name: \"{signal['logical_name']}\",")
-        lines.append(f"        bank: \"{signal['bank']}\",")
+        lines.append(f"        logical_name: {_rust_str_literal(signal['logical_name'])},")
+        lines.append(f"        bank: {_rust_str_literal(signal['bank'])},")
         lines.append(f"        pin: {signal['pin']},")
         lines.append(f"        direction: {dir_value},")
         lines.append(f"        active_level: {lvl_value},")


### PR DESCRIPTION
Add SGPIOM interrupt support and tighten descriptor/output handling.

- Implement HAL GpioInterrupt for SgpiomBankPort (configure sensitivity, enable/disable/clear/query); callbacks return UnsupportedFlags.
- RMW outputs via output-latch readback, not port_get_raw (samples input).
- Replace BankDevice::new with from_pin_offset; add reserved-pin mask and validate_mask; reject ngpios > 128.
- Extend sgpiom_smoke for the IRQ path; add sgpiom_irq integration test.
- Tooling: bound u32/ngpios/pin_offset, exclude bool from int checks, escape Rust string literals, index RESERVED_PINS_* by position.

<img width="1099" height="714" alt="image" src="https://github.com/user-attachments/assets/9d4bb07b-3ef4-436d-9920-c931d099894b" />
